### PR TITLE
Fix crash due to Where/In query which has many values

### DIFF
--- a/lib/etso/ets/match_specification.ex
+++ b/lib/etso/ets/match_specification.ex
@@ -48,10 +48,16 @@ defmodule Etso.ETS.MatchSpecification do
   defp build_condition(field_names, params, {:in, [], [field, value]}) do
     field_name = resolve_field_name(field)
     field_index = get_field_index(field_names, field_name)
+    field_values = resolve_field_values(params, value)
 
-    resolve_field_values(params, value)
-    |> Enum.map(&{:==, :"$#{field_index}", &1})
-    |> Enum.reduce(&{:orelse, &1, &2})
+    case field_values do
+      [] ->
+        []
+
+      values ->
+        [:orelse | Enum.map(values, &{:==, :"$#{field_index}", &1})]
+        |> List.to_tuple()
+    end
   end
 
   defp build_condition(field_names, _, {{:., [], [{:&, [], [0]}, field_name]}, [], []}) do


### PR DESCRIPTION
Hi! We use etso in production and it works very well. Thanks for the great library.
I found a crash that occurs under OTP 23.0, so I made a PR for it.

## Summary

- This will fix the crash caused by Where/In query which has many values. (cf. https://github.com/evadne/etso/pull/6)
- To avoid [ERL-592](https://bugs.erlang.org/browse/ERL-592) bug, fix `orlese` query to be flat.
    - This workaround is the one suggested in the comments of [ERL-732](https://bugs.erlang.org/browse/ERL-592).