### PR TITLE
Support JSON extract path expression

### DIFF
--- a/lib/etso/adapter/behaviour/queryable.ex
+++ b/lib/etso/adapter/behaviour/queryable.ex
@@ -7,21 +7,55 @@ defmodule Etso.Adapter.Behaviour.Queryable do
   alias Etso.ETS.ObjectsSorter
 
   @impl Ecto.Adapter.Queryable
-  def prepare(:all, query) do
-    {:nocache, query}
+  def prepare(:all, %Ecto.Query{} = query) do
+    {:nocache, {:select, query}}
   end
 
   @impl Ecto.Adapter.Queryable
-  def execute(%{repo: repo}, _, {:nocache, query}, params, _) do
+  def prepare(:delete_all, %Ecto.Query{wheres: []} = query) do
+    {:nocache, {:delete_all_objects, query}}
+  end
+
+  @impl Ecto.Adapter.Queryable
+  def prepare(:delete_all, %Ecto.Query{wheres: _} = query) do
+    {:nocache, {:match_delete, query}}
+  end
+
+  @impl Ecto.Adapter.Queryable
+  def execute(%{repo: repo}, _, {:nocache, {:select, query}}, params, _) do
     {_, schema} = query.from.source
     {:ok, ets_table} = TableRegistry.get_table(repo, schema)
     ets_match = MatchSpecification.build(query, params)
-    ets_objects = :ets.select(ets_table, [ets_match]) |> ObjectsSorter.sort(query)
-    {length(ets_objects), ets_objects}
+    ets_objects = :ets.select(ets_table, [ets_match])
+    ets_count = length(ets_objects)
+    {ets_count, ObjectsSorter.sort(ets_objects, query)}
   end
 
   @impl Ecto.Adapter.Queryable
-  def stream(%{repo: repo}, _, {:nocache, query}, params, options) do
+  def execute(%{repo: repo}, _, {:nocache, {:delete_all_objects, query}}, params, _) do
+    {_, schema} = query.from.source
+    {:ok, ets_table} = TableRegistry.get_table(repo, schema)
+    ets_match = MatchSpecification.build(query, params)
+    ets_objects = query.select && ObjectsSorter.sort(:ets.select(ets_table, [ets_match]), query)
+    ets_count = :ets.info(ets_table, :size)
+    true = :ets.delete_all_objects(ets_table)
+    {ets_count, ets_objects || nil}
+  end
+
+  @impl Ecto.Adapter.Queryable
+  def execute(%{repo: repo}, _, {:nocache, {:match_delete, query}}, params, _) do
+    {_, schema} = query.from.source
+    {:ok, ets_table} = TableRegistry.get_table(repo, schema)
+    ets_match = MatchSpecification.build(query, params)
+    ets_objects = query.select && ObjectsSorter.sort(:ets.select(ets_table, [ets_match]), query)
+    {ets_match_head, ets_match_body, _} = ets_match
+    ets_match = {ets_match_head, ets_match_body, [true]}
+    ets_count = :ets.select_delete(ets_table, [ets_match])
+    {ets_count, ets_objects || nil}
+  end
+
+  @impl Ecto.Adapter.Queryable
+  def stream(%{repo: repo}, _, {:nocache, {:select, query}}, params, options) do
     {_, schema} = query.from.source
     {:ok, ets_table} = TableRegistry.get_table(repo, schema)
     ets_match = MatchSpecification.build(query, params)

--- a/lib/etso/ets/match_specification.ex
+++ b/lib/etso/ets/match_specification.ex
@@ -1,13 +1,19 @@
 defmodule Etso.ETS.MatchSpecification do
   @moduledoc """
   The ETS Match Specifications module contains various functions which convert Ecto queries to
-  ETS Match Specifications in order to execute the given queries.
+  [ETS Match Specifications](https://www.erlang.org/doc/apps/erts/match_spec.html) in order to
+  execute the given queries with ETS with as much pushed down to ETS as possible.
+
+  The basic shape of the match head is `[$1, $2, $3, …]` where each field is a named variable, the
+  ordering of the fields is determined by `Etso.ETS.TableStructure`.
+
+  Conditions are compiled according to the wheres in the underlying Ecto query, while the body is
+  compiled based on the selected fields in the underlying Ecto query.
   """
 
   def build(query, params) do
     {_, schema} = query.from.source
     field_names = Etso.ETS.TableStructure.field_names(schema)
-
     match_head = build_head(field_names)
     match_conditions = build_conditions(field_names, params, query.wheres)
     match_body = [build_body(field_names, query.select.fields)]
@@ -45,13 +51,12 @@ defmodule Etso.ETS.MatchSpecification do
     end
   end
 
-  defp build_condition(field_names, params, {:in, [], [field, value]}) do
-    field_name = resolve_field_name(field)
-    field_index = get_field_index(field_names, field_name)
+  defp build_condition(field_names, params, {:in, [], [field, values]}) do
+    field_target = resolve_field_target(field_names, field)
 
-    case resolve_field_values(params, value) do
+    case resolve_param_values(params, values) do
       [] -> []
-      values -> List.to_tuple([:orelse | Enum.map(values, &{:==, :"$#{field_index}", &1})])
+      values -> List.to_tuple([:orelse | Enum.map(values, &{:==, field_target, &1})])
     end
   end
 
@@ -59,42 +64,64 @@ defmodule Etso.ETS.MatchSpecification do
     {:==, build_condition(field_names, params, field), nil}
   end
 
-  defp build_condition(field_names, _, {{:., [], [{:&, [], [0]}, field_name]}, [], []}) do
-    :"$#{get_field_index(field_names, field_name)}"
-  end
-
   defp build_condition(_, params, {:^, [], [index]}) do
     Enum.at(params, index)
   end
 
-  defp build_condition(_, _, value) when not is_tuple(value) do
+  defp build_condition(field_names, _params, field) when is_tuple(field) do
+    resolve_field_target(field_names, field)
+  end
+
+  defp build_condition(_, _, value) do
     value
   end
 
-  defp build_body(field_names, query_select_fields) do
-    for select_field <- query_select_fields do
-      field_name = resolve_field_name(select_field)
-      field_index = get_field_index(field_names, field_name)
-      :"$#{field_index}"
+  defp build_body(field_names, fields) do
+    for field <- fields do
+      resolve_field_target(field_names, field)
     end
   end
 
-  defp resolve_field_name(field) do
-    {{:., _, [{:&, [], [0]}, field_name]}, [], []} = field
-    field_name
+  defp resolve_field_target(field_names, {:json_extract_path, [], [field, path]}) do
+    field_target = resolve_field_target(field_names, field)
+    resolve_field_target_path(field_target, path)
   end
 
-  defp resolve_field_values(params, {:^, [], [index, count]}) do
+  defp resolve_field_target(field_names, {{:., _, [{:&, [], [0]}, field_name]}, [], []}) do
+    field_index = 1 + Enum.find_index(field_names, fn x -> x == field_name end)
+    :"$#{field_index}"
+  end
+
+  defp resolve_field_target_path(field_target, path) do
+    # - If the path component is a key, return {:map_get, key, target}
+    # - If the path component is a number, return {:hd, target} outside as many {:tl, _} around
+    #   as required. For example, [:metadata, 0] would be {:hd, {:map_get, :metadata, field}},
+    #   while [:metadata, 1] would be {:hd, {:tl, {:map_get, :metadata, field}}} (with one tl).
+
+    at = fn self ->
+      fn
+        condition, 0 -> {:hd, condition}
+        condition, index -> self.(self).({:tl, condition}, index - 1)
+      end
+    end
+
+    Enum.reduce(path, field_target, fn
+      key, condition when is_atom(key) or is_binary(key) -> {:map_get, key, condition}
+      index, condition when is_integer(index) -> at.(at).(condition, index)
+    end)
+  end
+
+  defp resolve_param_values(params, {:^, [], [index, count]}) do
     for index <- index..(index + count - 1) do
       Enum.at(params, index)
     end
   end
 
-  defp resolve_field_values(params, {:^, [], [index]}) do
+  defp resolve_param_values(params, {:^, [], [index]}) do
     Enum.at(params, index)
   end
 
-  defp get_field_index(field_names, field_name) do
-    1 + Enum.find_index(field_names, fn x -> x == field_name end)
+  defp resolve_param_values(_params, values) when is_list(values) do
+    values
   end
 end

--- a/priv/northwind/employees.json
+++ b/priv/northwind/employees.json
@@ -25,7 +25,23 @@
       1581
     ],
     "title": "Vice President Sales",
-    "titleOfCourtesy": "Dr."
+    "titleOfCourtesy": "Dr.",
+    "metadata": {
+      "twitter": "@andrew_fuller",
+      "photos": [
+        {
+          "storage": "a",
+          "url": "https://example.com/a"
+        },
+        {
+          "storage": "b",
+          "url": "https://example.com/b"
+        }
+      ],
+      "documents": {
+        "passport": "verified"
+      }
+    }
   },
   {
     "address": {

--- a/test/support/northwind/model/employee.ex
+++ b/test/support/northwind/model/employee.ex
@@ -13,6 +13,7 @@ defmodule Northwind.Model.Employee do
     field :hire_date, :date
     field :notes, :string
     field :territory_ids, {:array, :integer}
+    field :metadata, :map, default: %{}
 
     embeds_one :address, Model.Address
 


### PR DESCRIPTION
Previously, queries that check against JSON columns couldn't be used alongside this adapter. With the changes in this PR, we can now do this. see an example below:

```elixir
from(e in Model.Employee)
|> where([e], e.metadata["twitter"] == "@andrew_fuller")
|> Repo.one!()
```

Alongside these changes is a contribution from @evadne to support the `delete_all` function on the adapter.