### PR TITLE
feat: support field sources

### DIFF
--- a/lib/etso/adapter/behaviour/schema.ex
+++ b/lib/etso/adapter/behaviour/schema.ex
@@ -13,8 +13,8 @@ defmodule Etso.Adapter.Behaviour.Schema do
   @impl Ecto.Adapter.Schema
   def insert_all(%{repo: repo}, %{schema: schema}, _, entries, _, _, _, _) do
     {:ok, ets_table} = TableRegistry.get_table(repo, schema)
-    ets_field_names = TableStructure.field_names(schema)
-    ets_changes = TableStructure.entries_to_tuples(ets_field_names, entries)
+    ets_field_sources = TableStructure.field_sources(schema)
+    ets_changes = TableStructure.entries_to_tuples(ets_field_sources, entries)
     ets_result = :ets.insert_new(ets_table, ets_changes)
     if ets_result, do: {length(ets_changes), nil}, else: {0, nil}
   end
@@ -22,8 +22,8 @@ defmodule Etso.Adapter.Behaviour.Schema do
   @impl Ecto.Adapter.Schema
   def insert(%{repo: repo}, %{schema: schema}, fields, _, _, _) do
     {:ok, ets_table} = TableRegistry.get_table(repo, schema)
-    ets_field_names = TableStructure.field_names(schema)
-    ets_changes = TableStructure.fields_to_tuple(ets_field_names, fields)
+    ets_field_sources = TableStructure.field_sources(schema)
+    ets_changes = TableStructure.fields_to_tuple(ets_field_sources, fields)
     ets_result = :ets.insert_new(ets_table, ets_changes)
     if ets_result, do: {:ok, []}, else: {:invalid, [unique: "primary_key"]}
   end
@@ -48,11 +48,11 @@ defmodule Etso.Adapter.Behaviour.Schema do
   end
 
   defp build_ets_updates(schema, fields) do
-    ets_field_names = TableStructure.field_names(schema)
+    ets_field_sources = TableStructure.field_sources(schema)
 
     for {field_name, field_value} <- fields do
       position_fun = fn x -> x == field_name end
-      position = 1 + Enum.find_index(ets_field_names, position_fun)
+      position = 1 + Enum.find_index(ets_field_sources, position_fun)
       {position, field_value}
     end
   end

--- a/lib/etso/ets/table_structure.ex
+++ b/lib/etso/ets/table_structure.ex
@@ -11,6 +11,12 @@ defmodule Etso.ETS.TableStructure do
     primary_key ++ (fields -- primary_key)
   end
 
+  def field_sources(schema) do
+    schema
+    |> field_names()
+    |> Enum.map(fn field -> schema.__schema__(:field_source, field) end)
+  end
+
   def fields_to_tuple(field_names, fields) do
     field_names
     |> Enum.map(&Keyword.get(fields, &1, nil))

--- a/test/northwind/repo_test.exs
+++ b/test/northwind/repo_test.exs
@@ -182,7 +182,7 @@ defmodule Northwind.RepoTest do
 
   test "Delete Where" do
     query = Model.Employee |> where([e], e.employee_id in [1, 5])
-    assert [a, b] = Repo.all(query)
+    assert [_a, _b] = Repo.all(query)
     assert {2, nil} = Repo.delete_all(query)
     assert [] == Repo.all(query)
     refute [] == Repo.all(Model.Employee)
@@ -190,12 +190,12 @@ defmodule Northwind.RepoTest do
 
   test "Delete Where Select" do
     query = Model.Employee |> where([e], e.employee_id in [1, 5])
-    assert [a, b] = Repo.all(query)
+    assert [_a, _b] = Repo.all(query)
     assert {2, list} = Repo.delete_all(query |> select([e], {e, e.employee_id}))
     assert is_list(list)
     assert Enum.any?(list, &(elem(&1, 1) == 1))
     assert Enum.any?(list, &(elem(&1, 1) == 5))
-    assert [] = Repo.all(query)
+    assert [] == Repo.all(query)
     refute [] == Repo.all(Model.Employee)
   end
 

--- a/test/support/northwind/model/employee.ex
+++ b/test/support/northwind/model/employee.ex
@@ -4,7 +4,7 @@ defmodule Northwind.Model.Employee do
 
   schema "employees" do
     # field :employee_id, :integer
-    field :reports_to, :integer
+    field :reports_to, :integer, source: :manager_id
     field :first_name, :string
     field :last_name, :string
     field :title, :string


### PR DESCRIPTION
This PR allows the Ecto Schemas to define the `source` option. The `source` is not so useful in the usecase of an ETS storage, but in my usecase this is useful because I have a struct that have the `source` option defined and also want it to work with Etso.

Great lib by the way! I'm learning a lot about Ecto looking at the code :) 