### PR TITLE
relax ecto version constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Etso.MixProject do
 
   defp deps do
     [
-      {:ecto, "~> 3.8.3"},
+      {:ecto, "~> 3.8"},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:jason, "~> 1.1", only: :test, runtime: false}


### PR DESCRIPTION
Make it possible to use Ecto higher version than 3.8.3