### PR TITLE
Fix test warnings

### DIFF
--- a/test/northwind/repo_test.exs
+++ b/test/northwind/repo_test.exs
@@ -182,7 +182,7 @@ defmodule Northwind.RepoTest do
 
   test "Delete Where" do
     query = Model.Employee |> where([e], e.employee_id in [1, 5])
-    assert [a, b] = Repo.all(query)
+    assert [_a, _b] = Repo.all(query)
     assert {2, nil} = Repo.delete_all(query)
     assert [] == Repo.all(query)
     refute [] == Repo.all(Model.Employee)
@@ -190,7 +190,7 @@ defmodule Northwind.RepoTest do
 
   test "Delete Where Select" do
     query = Model.Employee |> where([e], e.employee_id in [1, 5])
-    assert [a, b] = Repo.all(query)
+    assert [_a, _b] = Repo.all(query)
     assert {2, list} = Repo.delete_all(query |> select([e], {e, e.employee_id}))
     assert is_list(list)
     assert Enum.any?(list, &(elem(&1, 1) == 1))


### PR DESCRIPTION
👋 Hello,

I am getting started with the etso project and before I contribute other changes I wanted to merge this small PR to fix the compiler warnings.

```bash
==> etso
Compiling 24 files (.ex)
Generated etso app
warning: variable "a" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/northwind/repo_test.exs:185: Northwind.RepoTest."test Delete Where"/1

warning: variable "b" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/northwind/repo_test.exs:185: Northwind.RepoTest."test Delete Where"/1

warning: variable "a" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/northwind/repo_test.exs:193: Northwind.RepoTest."test Delete Where Select"/1

warning: variable "b" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/northwind/repo_test.exs:193: Northwind.RepoTest."test Delete Where Select"/1
```