### PR TITLE
Reorder children in supervisor.ex

### DIFF
--- a/lib/etso/adapter/supervisor.ex
+++ b/lib/etso/adapter/supervisor.ex
@@ -18,8 +18,8 @@ defmodule Etso.Adapter.Supervisor do
   @impl Supervisor
   def init(repo) do
     children = [
-      {Etso.Adapter.TableSupervisor, repo},
-      {Etso.Adapter.TableRegistry, repo}
+      {Etso.Adapter.TableRegistry, repo},
+      {Etso.Adapter.TableSupervisor, repo}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
Ran into an issue where this happened
```
"Child :undefined of Supervisor MyRepo.TableSupervisor failed to start\n
** (exit) an exception was raised:\n
** (ArgumentError) unknown registry: MyRepo.TableRegistry\n
```

Had a quick glance at the code and the way it works now suggests that `TableSupervisor` is started before `TableRegistry` however all the calls to `TableSupervisor` seem to rely on `TableRegistry` being online.